### PR TITLE
Implement next roadmap task

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@
   - **Deliverable:** `web/src/components/ArchitectureCanvas.spec.js` with 80%+ coverage
   - **Tests:** N/A (this creates the testing foundation)
 
-- [ ] **0.1.3** Add test coverage enforcement
+- [x] **0.1.3** Add test coverage enforcement
   - Create `scripts/check-coverage.sh`
   - Configure minimum coverage thresholds
   - **Deliverable:** Script that fails if coverage < 95% (Go) or < 80% (Vue)

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -6,7 +6,12 @@ set -e
 GO_MIN_COVERAGE=95
 VUE_MIN_COVERAGE=80
 
+# Track overall pass/fail status
+EXIT_CODE=0
+
+echo "========================================"
 echo "=== Running Go Tests with Coverage ==="
+echo "========================================"
 go test -coverprofile=coverage.out ./...
 
 echo ""
@@ -22,15 +27,81 @@ echo "Minimum Required: ${GO_MIN_COVERAGE}%"
 
 # Check if coverage meets minimum threshold
 if (( $(echo "$TOTAL_COVERAGE < $GO_MIN_COVERAGE" | bc -l) )); then
-    echo "❌ FAILED: Coverage ${TOTAL_COVERAGE}% is below minimum ${GO_MIN_COVERAGE}%"
-    exit 1
+    echo "❌ FAILED: Go coverage ${TOTAL_COVERAGE}% is below minimum ${GO_MIN_COVERAGE}%"
+    EXIT_CODE=1
 else
-    echo "✅ PASSED: Coverage ${TOTAL_COVERAGE}% meets minimum ${GO_MIN_COVERAGE}%"
+    echo "✅ PASSED: Go coverage ${TOTAL_COVERAGE}% meets minimum ${GO_MIN_COVERAGE}%"
 fi
 
-# TODO: Add Vue/Vitest coverage check when frontend tests are set up
-# echo ""
-# echo "=== Running Vue Tests with Coverage ==="
-# cd web && npm test -- --coverage
+echo ""
+echo "========================================="
+echo "=== Running Vue Tests with Coverage ==="
+echo "========================================="
 
-exit 0
+# Change to web directory and run tests with coverage
+cd web
+
+# Run Vitest with coverage and capture output
+npm run test:coverage -- --run 2>&1 | tee /tmp/vue-coverage.txt
+
+# Parse coverage from Vitest text output
+# Look for the "All files" line in the coverage table
+if grep -q "All files" /tmp/vue-coverage.txt; then
+    # Extract coverage percentages from the "All files" line
+    # Format: All files          |     100 |    96.66 |     100 |     100 |
+    # Columns are: File | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+    COVERAGE_LINE=$(grep "All files" /tmp/vue-coverage.txt | tr -s ' ')
+
+    # Extract individual coverage metrics (columns: Stmts, Branch, Funcs, Lines)
+    VUE_STATEMENTS=$(echo "$COVERAGE_LINE" | awk -F '|' '{print $2}' | tr -d ' ')
+    VUE_BRANCHES=$(echo "$COVERAGE_LINE" | awk -F '|' '{print $3}' | tr -d ' ')
+    VUE_FUNCTIONS=$(echo "$COVERAGE_LINE" | awk -F '|' '{print $4}' | tr -d ' ')
+    VUE_LINES=$(echo "$COVERAGE_LINE" | awk -F '|' '{print $5}' | tr -d ' ')
+
+    echo ""
+    echo "=== Vue Coverage Summary ==="
+    echo "Statements: ${VUE_STATEMENTS}%"
+    echo "Branches:   ${VUE_BRANCHES}%"
+    echo "Functions:  ${VUE_FUNCTIONS}%"
+    echo "Lines:      ${VUE_LINES}%"
+    echo "Minimum Required: ${VUE_MIN_COVERAGE}%"
+
+    # Check all metrics against threshold
+    FAILED_METRICS=""
+    if (( $(echo "$VUE_STATEMENTS < $VUE_MIN_COVERAGE" | bc -l) )); then
+        FAILED_METRICS="${FAILED_METRICS}Statements (${VUE_STATEMENTS}%) "
+    fi
+    if (( $(echo "$VUE_BRANCHES < $VUE_MIN_COVERAGE" | bc -l) )); then
+        FAILED_METRICS="${FAILED_METRICS}Branches (${VUE_BRANCHES}%) "
+    fi
+    if (( $(echo "$VUE_FUNCTIONS < $VUE_MIN_COVERAGE" | bc -l) )); then
+        FAILED_METRICS="${FAILED_METRICS}Functions (${VUE_FUNCTIONS}%) "
+    fi
+    if (( $(echo "$VUE_LINES < $VUE_MIN_COVERAGE" | bc -l) )); then
+        FAILED_METRICS="${FAILED_METRICS}Lines (${VUE_LINES}%) "
+    fi
+
+    if [ -n "$FAILED_METRICS" ]; then
+        echo "❌ FAILED: Vue coverage below minimum ${VUE_MIN_COVERAGE}%: ${FAILED_METRICS}"
+        EXIT_CODE=1
+    else
+        echo "✅ PASSED: All Vue coverage metrics meet minimum ${VUE_MIN_COVERAGE}%"
+    fi
+else
+    echo "❌ FAILED: Could not parse Vue coverage output"
+    EXIT_CODE=1
+fi
+
+cd ..
+
+echo ""
+echo "========================================="
+echo "=== Coverage Check Summary ==="
+echo "========================================="
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "✅ All coverage requirements met!"
+else
+    echo "❌ Coverage requirements not met. See details above."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
This implements task 0.1.3 from the roadmap: Add test coverage enforcement.

Changes:
- Updated scripts/check-coverage.sh to include Vue/Vitest coverage checking
- Script now checks both Go coverage (95% threshold) and Vue coverage (80% threshold)
- Parses Vitest text output to extract coverage metrics (statements, branches, functions, lines)
- Reports detailed coverage summary for both Go and Vue
- Exits with error code if any coverage metric falls below threshold
- Updated ROADMAP.md to mark task 0.1.3 as complete

The script validates:
- Go coverage >= 95%
- Vue coverage >= 80% (all metrics: statements, branches, functions, lines)

Tested on current codebase:
- Go coverage: 58.1% (expected to be below threshold initially)
- Vue coverage: All metrics above 80% (100%, 96.66%, 100%, 100%)
- All existing tests pass